### PR TITLE
chore(gha): bump adrianjost/actions-surge.sh-teardown

### DIFF
--- a/.github/workflows/surge-teardown-old-domains.yml
+++ b/.github/workflows/surge-teardown-old-domains.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_UBUNTU }}
     steps:
       - name: Teardown surge deployments created more than 1 month ago
-        uses: adrianjost/actions-surge.sh-teardown@v1.0.3
+        uses: adrianjost/actions-surge.sh-teardown@v1.0.4
         with:
           regex: '[1-9]+ month.? ago'
         env:


### PR DESCRIPTION

### Notes

Fixes the bug described in https://github.com/bonitasoft/bonita-documentation-site/issues/771

We encountered the problems several times:
- Wed, 14 Aug 2024 17:16:03 GMT: https://github.com/process-analytics/surge.sh-pa-admin/actions/runs/10384452599/job/28776305212
- Sat, 17 Aug 2024 03:11:38 GMT https://github.com/process-analytics/surge.sh-pa-admin/actions/runs/10429089469/job/28886076767
- Wed, 21 Aug 2024 09:03:44 GMT https://github.com/process-analytics/surge.sh-pa-admin/actions/runs/10486851210/job/29045986219

✔️ Tested with the branch of this PR https://github.com/process-analytics/surge.sh-pa-admin/actions/runs/10525416686/job/29164158810
```
Download action repository 'adrianjost/actions-surge.sh-teardown@v1.0.4' (SHA:f8c2503a1cae5afc57859b9c6afc3fabdbfde027)
...
Run adrianjost/actions-surge.sh-teardown@v1.0.4
DryRun: false
search for projects that match /[1-9]+ month.? ago/i
found 5 projects for teardown
teardown process-analytics-process-analytics-dev-site_preview-pr-1301.surge.sh (last updated 1 month ago)
teardown process-analytics-process-analytics-dev-site_preview-pr-1298.surge.sh (last updated 1 month ago)
teardown process-analytics-process-analytics-dev-site_preview-pr-1282.surge.sh (last updated 1 month ago)
teardown process-analytics-process-analytics-dev-site_preview-pr-1296.surge.sh (last updated 1 month ago)
teardown process-analytics-bv-experimental-add-ons-demo-pr-260.surge.sh (last updated 1 month ago)
removed process-analytics-process-analytics-dev-site_preview-pr-1282.surge.sh
removed process-analytics-process-analytics-dev-site_preview-pr-1298.surge.sh
removed process-analytics-process-analytics-dev-site_preview-pr-1296.surge.sh
removed process-analytics-bv-experimental-add-ons-demo-pr-260.surge.sh
removed process-analytics-process-analytics-dev-site_preview-pr-1301.surge.sh
```